### PR TITLE
Fix category anchor IDs

### DIFF
--- a/templates/web/groceries-template.html.erb
+++ b/templates/web/groceries-template.html.erb
@@ -71,7 +71,8 @@
     
     <div id="recipe-selector" class="hidden-until-js">
       <%- grouped_recipes.each do |category, recipes| -%>
-      <details id="<%= category.downcase %>" open>
+      <% category_id = category.downcase.gsub(/[^a-z0-9]+/, '-') %>
+      <details id="<%= category_id %>" open>
         <summary><%= category %></summary>
         <ul>
         <%- recipes.each do |recipe| -%>

--- a/templates/web/homepage-template.html.erb
+++ b/templates/web/homepage-template.html.erb
@@ -29,13 +29,15 @@
       <div class="toc_nav">
         <ul>
           <%- grouped_recipes.each do |category, recipes| -%>
-            <li><a href="#<%= category.downcase %>"><%= category %></a></li>
+            <% category_id = category.downcase.gsub(/[^a-z0-9]+/, '-') %>
+            <li><a href="#<%= category_id %>"><%= category %></a></li>
           <%- end -%>
         </ul>
       </div>
-      
+
       <%- grouped_recipes.each do |category, recipes| -%>
-      <section id="<%= category.downcase %>">
+      <% category_id = category.downcase.gsub(/[^a-z0-9]+/, '-') %>
+      <section id="<%= category_id %>">
         <h2><%= category %></h2>
         <ul>
           <%- recipes.each do |recipe| -%>


### PR DESCRIPTION
## Summary
- sanitize recipe category IDs in homepage and grocery templates

## Testing
- `ruby -e "require 'erb'; ERB.new(File.read('templates/web/homepage-template.html.erb'))"`
- `ruby -e "require 'erb'; ERB.new(File.read('templates/web/groceries-template.html.erb'))"`
- `ruby bin/generate` *(fails: cannot load such file -- redcarpet)*

------
https://chatgpt.com/codex/tasks/task_e_684dd6ac6b748328a543b7f19d0ab71e